### PR TITLE
Isolate pki_dir per salt-call environment to prevent race condition

### DIFF
--- a/.check_pillar_for_roster.sh
+++ b/.check_pillar_for_roster.sh
@@ -39,8 +39,8 @@ prepare_salt_call_environment() {
 
     mkdir -p "${environment}/var/cache" "${environment}/var/run"
     printf '%s: %s\n' "cachedir" "${environment}/var/cache" \
-                      "pidfile" "${environment}/var/run/salt-minion.pid" > "${environment}/minion"
-
+                      "pidfile"  "${environment}/var/run/salt-minion.pid" \
+                      "pki_dir"  "${environment}/pki/minion" > "${environment}/minion"
 }
 
 check_pillars() {


### PR DESCRIPTION
`.check_pillar_for_roster.sh` spawns up to 10 parallel salt-call processes. Each job was isolated via --config-dir with its own cachedir and pidfile, but pki_dir was left at the default /etc/salt/pki/minion — shared across all jobs. All processes raced to create the same directory inside verify_env, hitting a TOCTOU window, and a random process failed with [Errno 17] File exists.

Override pki_dir to ${environment}/pki/minion so every job gets its own PKI tree (already populated by the prior `cp -R /etc/salt/.`).