### PR TITLE
feat/vault_salt_sdb

### DIFF
--- a/.docker-misc.bash
+++ b/.docker-misc.bash
@@ -64,10 +64,16 @@ drun() {
     find "${path}/pillar/top_sls" -not -type d -print0 | grep -vzP '\.swp$|_?top\.sls$' | sort -z | xargs -0 -I{} bash -c "cat {} <(echo) >> \"$top_file\""
 
     if [[ ! $(docker ps --format "{{.Names}}" --filter "name=${name}-$USER") =~ ${name}-$USER ]] ; then
+        # vault_salt_sdb: mount the operator's AppRole creds read-only when present.
+        # Self-gating: absent file (vault not used for this repo) -> empty array -> no mount.
+        local auth_conf="$HOME/.config/vault_salt_sdb/auth.conf"
+        local auth_mount=()
+        [[ -f $auth_conf ]] && auth_mount=(-v "$auth_conf:/root/.config/vault_salt_sdb/auth.conf:ro")
         docker run --hostname salt --detach --rm --name "${name}-$USER" \
             --volume "$top_file:/srv/pillar/top.sls" \
             --volume "${path}/:/srv/" \
             --volume "$SSH_AUTH_SOCK:/root/.ssh-agent" \
+            "${auth_mount[@]}" \
             --env SSH_AUTH_SOCK=/root/.ssh-agent \
             "${name}:$USER" \
             -- \

--- a/Dockerfile
+++ b/Dockerfile
@@ -65,6 +65,7 @@ COPY .check_pillar_for_roster.sh /.check_pillar_for_roster.sh
 COPY .salt-ssh-hooks /.salt-ssh-hooks
 COPY etc/salt/master /etc/salt/master
 COPY etc/salt/master.d /etc/salt/master.d
+COPY etc/salt/minion.d /etc/salt/minion.d
 COPY etc/salt/roster* /etc/salt/
 COPY README.md /srv/README.md
 COPY files /srv/files

--- a/README.md
+++ b/README.md
@@ -38,6 +38,54 @@ Fill the repo with some additional data:
 For Salt-SSH:
 - `etc/salt/roster` (see roster.example in `.salt-project-template`)
 
+# Secrets with Vault (vault_salt_sdb)
+This template ships a custom SDB driver (`salt/extmods/sdb/vault_salt_sdb.py`) that reads
+secrets from HashiCorp Vault (KV v2) instead of keeping them in plaintext pillar. The driver,
+its `extmods.conf` and the `minion.d` wiring are always installed but stay dormant until a
+profile is configured, so repos that do not use Vault are unaffected.
+
+## Enable at install time
+Set both vars in `template_install.sh` (presence of `VAULT_SDB_URL` turns the feature on):
+```
+VAULT_SDB_URL=https://vault.example.com \
+VAULT_SDB_PREFIX=iac/example \
+```
+- `VAULT_SDB_URL` - Vault address. If unset, `install.sh` strips out the profile and the macro
+  (the driver itself stays installed, dormant).
+- `VAULT_SDB_PREFIX` - per-repo KV path prefix, e.g. `iac/<project>`. Required when the URL is set.
+
+This generates `etc/salt/master.d/vault_salt_sdb.conf` (mirrored into `minion.d` via symlink).
+
+## Runtime auth
+The profile loads credentials from `/root/.config/vault_salt_sdb/auth.conf`, kept OUT of the
+repo. Provide it on each Salt Master and on the salt-ssh runner (for local docker runs it is
+bind-mounted automatically, see `.docker-misc.bash`):
+```
+mkdir -p ~/.config/vault_salt_sdb
+cat > ~/.config/vault_salt_sdb/auth.conf <<'EOF'
+method: approle
+role_id: <role-id>
+secret_id: <secret-id>
+EOF
+chmod 600 ~/.config/vault_salt_sdb/auth.conf
+```
+Secret values are cached at `/root/.cache/vault_salt_sdb/cache.json` (mode 0600) for a short
+freshness window and as an outage fallback; tune via `cache_*` keys in the profile.
+
+## Using secrets in pillar
+Import the macro and reference a secret by its path under the prefix:
+```
+{% from 'vault_salt_sdb.jinja' import secret %}
+
+myapp:
+  db_password: "{{ secret('app/db/password') }}"
+```
+`secret('app/db/password')` expands to `sdb://vault_salt_sdb/<VAULT_SDB_PREFIX>/app/db/password`.
+The URI is `<mount>/<path>/<key>`: the first segment is the KV mount, the last is the field
+inside the secret, the middle is the secret path. The macro keeps the per-repo prefix in one
+place so secret references stay copy-paste identical across repos. You can also call the driver
+directly: `{{ salt['sdb.get']('sdb://vault_salt_sdb/iac/example/app/db/password') }}`.
+
 # Use the repository
 Either push to GitLab and pipeline should deploy depo code to Salt Masters or build the docker image
 Then use [Gitlab Pipelines](https://github.com/microdevops-com/gitlab-server-job) to run salt/salt-ssh.

--- a/README.md
+++ b/README.md
@@ -45,14 +45,14 @@ its `extmods.conf` and the `minion.d` wiring are always installed but stay dorma
 profile is configured, so repos that do not use Vault are unaffected.
 
 ## Enable at install time
-Set both vars in `template_install.sh` (presence of `VAULT_SDB_URL` turns the feature on):
+Set both vars in `template_install.sh` (presence of `VAULT_SALT_SDB_URL` turns the feature on):
 ```
-VAULT_SDB_URL=https://vault.example.com \
-VAULT_SDB_PREFIX=iac/example \
+VAULT_SALT_SDB_URL=https://vault.example.com \
+VAULT_SALT_SDB_PREFIX=iac/example \
 ```
-- `VAULT_SDB_URL` - Vault address. If unset, `install.sh` strips out the profile and the macro
+- `VAULT_SALT_SDB_URL` - Vault address. If unset, `install.sh` strips out the profile and the macro
   (the driver itself stays installed, dormant).
-- `VAULT_SDB_PREFIX` - per-repo KV path prefix, e.g. `iac/<project>`. Required when the URL is set.
+- `VAULT_SALT_SDB_PREFIX` - per-repo KV path prefix, e.g. `iac/<project>`. Required when the URL is set.
 
 This generates `etc/salt/master.d/vault_salt_sdb.conf` (mirrored into `minion.d` via symlink).
 
@@ -80,7 +80,7 @@ Import the macro and reference a secret by its path under the prefix:
 myapp:
   db_password: "{{ secret('app/db/password') }}"
 ```
-`secret('app/db/password')` expands to `sdb://vault_salt_sdb/<VAULT_SDB_PREFIX>/app/db/password`.
+`secret('app/db/password')` expands to `sdb://vault_salt_sdb/<VAULT_SALT_SDB_PREFIX>/app/db/password`.
 The URI is `<mount>/<path>/<key>`: the first segment is the KV mount, the last is the field
 inside the secret, the middle is the secret path. The macro keeps the per-repo prefix in one
 place so secret references stay copy-paste identical across repos. You can also call the driver

--- a/etc/salt/master.d/extmods.conf
+++ b/etc/salt/master.d/extmods.conf
@@ -1,0 +1,1 @@
+extension_modules: /srv/salt/extmods

--- a/etc/salt/master.d/vault_salt_sdb.conf
+++ b/etc/salt/master.d/vault_salt_sdb.conf
@@ -1,6 +1,6 @@
 vault_salt_sdb:
   driver: vault_salt_sdb
-  url: __VAULT_SDB_URL__
+  url: __VAULT_SALT_SDB_URL__
   verify: true
   timeout: 5
   kv_version: 2

--- a/etc/salt/master.d/vault_salt_sdb.conf
+++ b/etc/salt/master.d/vault_salt_sdb.conf
@@ -1,0 +1,16 @@
+vault_salt_sdb:
+  driver: vault_salt_sdb
+  url: __VAULT_SDB_URL__
+  verify: true
+  timeout: 5
+  kv_version: 2
+  outage_cooldown: 30
+  cache_secrets: true
+  cache_fresh_for: 60
+  cache_offline_max_age: 3600
+  cache_path: /root/.cache/vault_salt_sdb/cache.json
+  auth_file: /root/.config/vault_salt_sdb/auth.conf
+  # Cache is plaintext at 0600 on a dedicated, root-only host — same posture as
+  # auth.conf next to it — so silence the unencrypted-cache warning (it would
+  # otherwise hit stderr and fail the pillar check). See cache_encryption_key to encrypt.
+  warn_plaintext_cache: false

--- a/etc/salt/minion.d/extmods.conf
+++ b/etc/salt/minion.d/extmods.conf
@@ -1,0 +1,1 @@
+../master.d/extmods.conf

--- a/etc/salt/minion.d/vault_salt_sdb.conf
+++ b/etc/salt/minion.d/vault_salt_sdb.conf
@@ -1,0 +1,1 @@
+../master.d/vault_salt_sdb.conf

--- a/install.sh
+++ b/install.sh
@@ -91,6 +91,16 @@ function sed_inplace_common () {
 	else
 		local LOCAL_ALERTA_API_KEY=${ALERTA_API_KEY}
 	fi
+	if [[ -z ${VAULT_SDB_URL} ]]; then
+		local LOCAL_VAULT_SDB_URL=__not_set_in_template_install__
+	else
+		local LOCAL_VAULT_SDB_URL=${VAULT_SDB_URL}
+	fi
+	if [[ -z ${VAULT_SDB_PREFIX} ]]; then
+		local LOCAL_VAULT_SDB_PREFIX=__not_set_in_template_install__
+	else
+		local LOCAL_VAULT_SDB_PREFIX=${VAULT_SDB_PREFIX}
+	fi
 	sed -i \
 		-e "s/__CLIENT__/${CLIENT}/g" \
 		-e "s/__CLIENT_FULL__/${CLIENT_FULL}/g" \
@@ -101,6 +111,8 @@ function sed_inplace_common () {
 		-e "s/__MONITORING_ENABLED__/${MONITORING_ENABLED}/g" \
 		-e "s#__ALERTA_URL__#${LOCAL_ALERTA_URL}#g" \
 		-e "s/__ALERTA_API_KEY__/${LOCAL_ALERTA_API_KEY}/g" \
+		-e "s#__VAULT_SDB_URL__#${LOCAL_VAULT_SDB_URL}#g" \
+		-e "s#__VAULT_SDB_PREFIX__#${LOCAL_VAULT_SDB_PREFIX}#g" \
 		-e "s/__HB_RECEIVER_HN__/${HB_RECEIVER_HN}/g" \
 		-e "s/__HB_TOKEN__/${HB_TOKEN}/g" \
 		-e "s/__SENTRY_DOMAIN__/${SENTRY_DOMAIN}/g" \
@@ -330,7 +342,22 @@ cp -Rf etc/apt $1/etc
 cp -f etc/salt/master $1/etc/salt/master
 cp -f etc/ssh/ssh_config $1/etc/ssh/ssh_config
 rsync_without_delete etc/salt/master.d $1/etc/salt/master.d
+rsync_without_delete etc/salt/minion.d $1/etc/salt/minion.d
 rsync_without_delete include $1/include
+
+# vault_salt_sdb - the driver (salt/extmods/sdb), extmods.conf and the minion.d wiring
+# stay installed unconditionally (harmless when idle, ready for a manual setup later;
+# minion.d/extmods.conf is also what lets salt-call --local find the driver). The toggle
+# only governs the operator-facing profile that bakes in URL/prefix and the macro using it.
+if [[ -n ${VAULT_SDB_URL} ]]; then
+	if [[ -z ${VAULT_SDB_PREFIX} ]]; then echo Var VAULT_SDB_PREFIX required when VAULT_SDB_URL is set; exit 1; fi
+	sed_inplace_common $1/etc/salt/master.d/vault_salt_sdb.conf
+	sed_inplace_common $1/pillar/vault_salt_sdb.jinja
+else
+	rm -f $1/etc/salt/master.d/vault_salt_sdb.conf
+	rm -f $1/etc/salt/minion.d/vault_salt_sdb.conf
+	rm -f $1/pillar/vault_salt_sdb.jinja
+fi
 
 # Get inside templated repo
 pushd $1

--- a/install.sh
+++ b/install.sh
@@ -91,15 +91,15 @@ function sed_inplace_common () {
 	else
 		local LOCAL_ALERTA_API_KEY=${ALERTA_API_KEY}
 	fi
-	if [[ -z ${VAULT_SDB_URL} ]]; then
-		local LOCAL_VAULT_SDB_URL=__not_set_in_template_install__
+	if [[ -z ${VAULT_SALT_SDB_URL} ]]; then
+		local LOCAL_VAULT_SALT_SDB_URL=__not_set_in_template_install__
 	else
-		local LOCAL_VAULT_SDB_URL=${VAULT_SDB_URL}
+		local LOCAL_VAULT_SALT_SDB_URL=${VAULT_SALT_SDB_URL}
 	fi
-	if [[ -z ${VAULT_SDB_PREFIX} ]]; then
-		local LOCAL_VAULT_SDB_PREFIX=__not_set_in_template_install__
+	if [[ -z ${VAULT_SALT_SDB_PREFIX} ]]; then
+		local LOCAL_VAULT_SALT_SDB_PREFIX=__not_set_in_template_install__
 	else
-		local LOCAL_VAULT_SDB_PREFIX=${VAULT_SDB_PREFIX}
+		local LOCAL_VAULT_SALT_SDB_PREFIX=${VAULT_SALT_SDB_PREFIX}
 	fi
 	sed -i \
 		-e "s/__CLIENT__/${CLIENT}/g" \
@@ -111,8 +111,8 @@ function sed_inplace_common () {
 		-e "s/__MONITORING_ENABLED__/${MONITORING_ENABLED}/g" \
 		-e "s#__ALERTA_URL__#${LOCAL_ALERTA_URL}#g" \
 		-e "s/__ALERTA_API_KEY__/${LOCAL_ALERTA_API_KEY}/g" \
-		-e "s#__VAULT_SDB_URL__#${LOCAL_VAULT_SDB_URL}#g" \
-		-e "s#__VAULT_SDB_PREFIX__#${LOCAL_VAULT_SDB_PREFIX}#g" \
+		-e "s#__VAULT_SALT_SDB_URL__#${LOCAL_VAULT_SALT_SDB_URL}#g" \
+		-e "s#__VAULT_SALT_SDB_PREFIX__#${LOCAL_VAULT_SALT_SDB_PREFIX}#g" \
 		-e "s/__HB_RECEIVER_HN__/${HB_RECEIVER_HN}/g" \
 		-e "s/__HB_TOKEN__/${HB_TOKEN}/g" \
 		-e "s/__SENTRY_DOMAIN__/${SENTRY_DOMAIN}/g" \
@@ -349,8 +349,8 @@ rsync_without_delete include $1/include
 # stay installed unconditionally (harmless when idle, ready for a manual setup later;
 # minion.d/extmods.conf is also what lets salt-call --local find the driver). The toggle
 # only governs the operator-facing profile that bakes in URL/prefix and the macro using it.
-if [[ -n ${VAULT_SDB_URL} ]]; then
-	if [[ -z ${VAULT_SDB_PREFIX} ]]; then echo Var VAULT_SDB_PREFIX required when VAULT_SDB_URL is set; exit 1; fi
+if [[ -n ${VAULT_SALT_SDB_URL} ]]; then
+	if [[ -z ${VAULT_SALT_SDB_PREFIX} ]]; then echo Var VAULT_SALT_SDB_PREFIX required when VAULT_SALT_SDB_URL is set; exit 1; fi
 	sed_inplace_common $1/etc/salt/master.d/vault_salt_sdb.conf
 	sed_inplace_common $1/pillar/vault_salt_sdb.jinja
 else

--- a/pillar/vault_salt_sdb.jinja
+++ b/pillar/vault_salt_sdb.jinja
@@ -1,3 +1,3 @@
 {%- macro secret(path) -%}
-{{ salt['sdb.get']('sdb://vault_salt_sdb/__VAULT_SDB_PREFIX__/' ~ path) }}
+{{ salt['sdb.get']('sdb://vault_salt_sdb/__VAULT_SALT_SDB_PREFIX__/' ~ path) }}
 {%- endmacro -%}

--- a/pillar/vault_salt_sdb.jinja
+++ b/pillar/vault_salt_sdb.jinja
@@ -1,0 +1,3 @@
+{%- macro secret(path) -%}
+{{ salt['sdb.get']('sdb://vault_salt_sdb/__VAULT_SDB_PREFIX__/' ~ path) }}
+{%- endmacro -%}

--- a/salt/extmods/sdb/vault_salt_sdb.py
+++ b/salt/extmods/sdb/vault_salt_sdb.py
@@ -7,6 +7,8 @@ Built for salt-ssh on Salt 3006.
 
 Version history:
 * 2026-06-16: initial version
+* 2026-06-21: cache file written 0600 (was 0644); dropped dead `cached` arg from
+  _extract; documented lease_duration-0 fallback and cache_fresh_for staleness window.
 
 Profile (e.g. /etc/salt/master.d/vault.conf):
 
@@ -27,6 +29,7 @@ Profile (e.g. /etc/salt/master.d/vault.conf):
       kv_version: 2                 # optional; autodetected if omitted
       cache_secrets: false          # keep secret VALUES on disk (default: false = fail-closed)
       cache_fresh_for: 60           # reuse a cached value without calling Vault if younger, seconds
+                                    # (note: a rotated secret is not observed until this window lapses)
       cache_offline_max_age: 3600   # if Vault is unreachable, reuse a cached value if younger, seconds
       cache_name: <name>            # optional; cache filename component (default: git repo + hash)
       cache_path: <path>            # optional; full cache file path override
@@ -235,7 +238,7 @@ def _save_cache(profile):
         try:
             with os.fdopen(fd, "wb") as fh:
                 fh.write(raw)
-            os.chmod(tmp, 0o644)  # readable; pair with cache_encryption_key to keep contents safe
+            os.chmod(tmp, 0o600)  # owner-only: file holds a live Vault token + (optionally) plaintext secrets
             os.replace(tmp, path)          # atomic
             tmp = None
         finally:
@@ -349,6 +352,8 @@ def _token(profile, force=False):
             "vault_salt_sdb: unexpected AppRole login response: {}".format(exc)
         )
 
+    # lease_duration 0 (e.g. root/non-expiring tokens) -> fall back to a short 60s
+    # cache rather than treating the token as valid forever.
     ttl = body_auth.get("lease_duration", 0) or 60
     cache["tokens"][ckey] = {"token": token, "expires_at": time.time() + ttl}
     _save_cache(profile)
@@ -443,7 +448,7 @@ def _read_secret(profile, url, mount, path):
     return data
 
 
-def _extract(data, field, path, cached=False):
+def _extract(data, field, path):
     if field in data:
         return data[field]
     available = ", ".join(sorted(data.keys())) or "(none)"
@@ -474,7 +479,7 @@ def get(key, profile=None, **kwargs):
 
     # 0) in-memory per-render dedup: this path already resolved this process
     if skey in _RENDER_SECRETS:
-        return _extract(_RENDER_SECRETS[skey], field, path, cached=True)
+        return _extract(_RENDER_SECRETS[skey], field, path)
 
     cache_on = bool(profile.get("cache_secrets"))
     cache_fresh_for = int(profile.get("cache_fresh_for", 60))
@@ -489,7 +494,7 @@ def get(key, profile=None, **kwargs):
                 mount, path, int(now - ent.get("cached_at", 0)),
             )
             _RENDER_SECRETS[skey] = ent["data"]
-            return _extract(ent["data"], field, path, cached=True)
+            return _extract(ent["data"], field, path)
 
     # 2) read from Vault
     try:
@@ -505,7 +510,7 @@ def get(key, profile=None, **kwargs):
                     exc, mount, path, int(now - ent.get("cached_at", 0)),
                 )
                 _RENDER_SECRETS[skey] = ent["data"]
-                return _extract(ent["data"], field, path, cached=True)
+                return _extract(ent["data"], field, path)
         raise salt.exceptions.CommandExecutionError(
             "vault_salt_sdb: Vault unreachable and no usable cache for {}/{}: {}".format(mount, path, exc)
         )
@@ -526,4 +531,4 @@ def get(key, profile=None, **kwargs):
         cache["secrets"][skey] = {"data": data, "cached_at": now}
         _save_cache(profile)
 
-    return _extract(data, field, path, cached=False)
+    return _extract(data, field, path)

--- a/salt/extmods/sdb/vault_salt_sdb.py
+++ b/salt/extmods/sdb/vault_salt_sdb.py
@@ -1,0 +1,529 @@
+"""
+SDB module: read HashiCorp Vault KV secrets directly (token / AppRole),
+with stock-sdb-compatible URI syntax, a file-based token cache, an optional
+two-tier value cache (freshness + outage fallback), optional cache encryption,
+fail-closed errors, an in-process circuit breaker, and per-render path dedup.
+Built for salt-ssh on Salt 3006.
+
+Version history:
+* 2026-06-16: initial version
+
+Profile (e.g. /etc/salt/master.d/vault.conf):
+
+    custom_vault_driver:
+      driver: vault_salt_sdb
+      url: https://vault.dev.opscore.org
+      auth:                         # inline auth (optional when auth_file is used)
+        method: approle          # or: token
+        role_id: <role-id>
+        secret_id: <secret-id>
+        # method: token -> token: <token>
+      auth_file: ~/.config/vault_salt_sdb/auth.conf   # optional; load auth from a separate
+                                    # file so credentials stay OUT of this config. Keys there
+                                    # OVERRIDE the inline auth above. Used automatically if it exists.
+      verify: true                  # TLS verify (default: true)
+      timeout: 10                   # request timeout, seconds (default: 10)
+      outage_cooldown: 30           # after Vault fails, skip it for this many seconds (default: 30)
+      kv_version: 2                 # optional; autodetected if omitted
+      cache_secrets: false          # keep secret VALUES on disk (default: false = fail-closed)
+      cache_fresh_for: 60           # reuse a cached value without calling Vault if younger, seconds
+      cache_offline_max_age: 3600   # if Vault is unreachable, reuse a cached value if younger, seconds
+      cache_name: <name>            # optional; cache filename component (default: git repo + hash)
+      cache_path: <path>            # optional; full cache file path override
+      cache_encryption_key: <pass>  # optional; if set, the cache file is encrypted
+      warn_plaintext_cache: true    # log the "cache is unencrypted" warning (default: true;
+                                    # set false to silence it, e.g. in the minion.d/check config)
+
+URI:  sdb://<profile>/<mount>/<path>/<key>          (key = last segment)
+      sdb://custom_vault_driver/salt/opscore/tst/nextcloud/admin_pass
+      -> GET <url>/v1/salt/data/opscore/tst/nextcloud ; return key 'admin_pass'
+
+Performance during an outage:
+  * Circuit breaker: the first connection failure is recorded in the cache file
+    for `outage_cooldown` seconds; subsequent lookups (even in fresh render contexts,
+    as salt-ssh uses) skip the network and fall back to cache. One timeout per
+    breaker window, not per key. The marker clears once Vault answers again.
+  * Per-render dedup: within one process each secret PATH is fetched at most once.
+
+Auth file (auth_file; default ~/.config/vault_salt_sdb/auth.conf; chmod 600). Same
+keys as the inline `auth:` block, for example:
+
+    method: approle
+    role_id: <role-id>
+    secret_id: <secret-id>
+    # or:  method: token  /  token: <vault-token>
+"""
+import base64
+import hashlib
+import json
+import logging
+import os
+import re
+import tempfile
+import time
+
+import requests
+import yaml
+
+import salt.exceptions
+
+log = logging.getLogger(__name__)
+
+__virtualname__ = "vault_salt_sdb"
+
+_SESSION = None
+_CACHES = {}            # cache_path -> {"tokens": {}, "kv": {}, "secrets": {}}
+_RENDER_SECRETS = {}    # "url|mount|path" -> data dict (this process only)
+_VAULT_DOWN = set()     # base urls found unreachable this process (circuit breaker)
+_REPO_ID = None         # cached per-repo identifier used in the cache filename
+_AUTH_FILES = {}        # auth_file path -> parsed auth dict (this process only)
+_WARNED_PLAINTEXT = False
+
+DEFAULT_AUTH_FILE = "~/.config/vault_salt_sdb/auth.conf"
+
+
+class _VaultUnreachable(Exception):
+    """Vault could not be reached (network / timeout / 5xx / sealed)."""
+
+
+def __virtual__():
+    return __virtualname__
+
+
+# --------------------------------------------------------------------------- #
+# infra: session, encryption, cache file
+# --------------------------------------------------------------------------- #
+def _session():
+    global _SESSION
+    if _SESSION is None:
+        _SESSION = requests.Session()
+    return _SESSION
+
+
+def _timeout(profile):
+    return profile.get("timeout", 10)
+
+
+def _mark_down(profile):
+    base = profile["url"].rstrip("/")
+    _VAULT_DOWN.add(base)
+    cache = _load_cache(profile)
+    cache.setdefault("down", {})[base] = time.time()
+    _save_cache(profile)
+
+
+def _down(profile, msg):
+    _mark_down(profile)
+    raise _VaultUnreachable(msg)
+
+
+def _request(profile, method, full_url, **kw):
+    base = profile["url"].rstrip("/")
+    cache = _load_cache(profile)
+    down = cache.setdefault("down", {})
+    outage_cooldown = int(profile.get("outage_cooldown", 30))
+    # Circuit breaker, persisted to the cache file so it survives salt-ssh
+    # rendering each sdb lookup in a fresh context: if Vault failed recently,
+    # skip the network entirely and let the caller fall back to cache.
+    if base in _VAULT_DOWN or (down.get(base) and time.time() - down[base] < outage_cooldown):
+        raise _VaultUnreachable("Vault marked unreachable recently; skipping connection")
+    try:
+        r = _session().request(
+            method, full_url,
+            verify=profile.get("verify", True),
+            timeout=_timeout(profile),
+            **kw
+        )
+    except requests.exceptions.RequestException as exc:
+        _mark_down(profile)
+        raise _VaultUnreachable(str(exc))
+    # got an HTTP response -> Vault answered; clear any stale down marker
+    if base in down:
+        down.pop(base, None)
+        _save_cache(profile)
+    _VAULT_DOWN.discard(base)
+    return r
+
+
+def _fernet(cache_encryption_key):
+    try:
+        from cryptography.fernet import Fernet
+    except ImportError:
+        raise salt.exceptions.CommandExecutionError(
+            "vault_salt_sdb: cache_encryption_key is set but the 'cryptography' library is unavailable"
+        )
+    fkey = base64.urlsafe_b64encode(hashlib.sha256(cache_encryption_key.encode()).digest())
+    return Fernet(fkey)
+
+
+def _repo_id():
+    """Stable per-repo identifier for the cache filename: git repo name + short
+    hash of its absolute path (so same-named repos in different paths don't clash)."""
+    global _REPO_ID
+    if _REPO_ID is not None:
+        return _REPO_ID
+    try:
+        import subprocess
+        top = subprocess.check_output(
+            ["git", "rev-parse", "--show-toplevel"],
+            stderr=subprocess.DEVNULL,
+            timeout=5,
+        ).decode().strip()
+    except Exception:
+        top = os.getcwd()
+    name = re.sub(r"[^A-Za-z0-9._-]", "_", os.path.basename(top.rstrip("/")) or "repo")
+    short = hashlib.sha256(top.encode()).hexdigest()[:8]
+    _REPO_ID = "{}_{}".format(name, short)
+    return _REPO_ID
+
+
+def _cache_path(profile):
+    # Keep the cache OUTSIDE file_roots / the salt repo: salt-ssh scans those dirs
+    # (an unreadable file there breaks "checking context"), and a cache holding
+    # secrets could get git-committed. Default: per-user dir, per-repo filename.
+    explicit = profile.get("cache_path")
+    if explicit:
+        return os.path.expanduser(explicit)
+    name = profile.get("cache_name") or _repo_id()
+    return os.path.expanduser(
+        os.path.join("~", ".cache", "vault_salt_sdb_{}.json".format(name))
+    )
+
+
+def _empty_cache():
+    return {"tokens": {}, "kv": {}, "secrets": {}, "down": {}}
+
+
+def _load_cache(profile):
+    path = _cache_path(profile)
+    if path in _CACHES:
+        return _CACHES[path]
+    cache = _empty_cache()
+    try:
+        with open(path, "rb") as fh:
+            raw = fh.read()
+        if raw:
+            if profile.get("cache_encryption_key"):
+                raw = _fernet(profile["cache_encryption_key"]).decrypt(raw)
+            loaded = json.loads(raw)
+            for section in cache:
+                got = loaded.get(section)
+                if isinstance(got, dict):
+                    cache[section] = got
+    except FileNotFoundError:
+        pass
+    except salt.exceptions.CommandExecutionError:
+        raise
+    except Exception as exc:        # corrupt file or wrong key -> ignore, rebuild
+        log.warning("vault_salt_sdb: ignoring unreadable cache %s: %s", path, exc)
+    _CACHES[path] = cache
+    return cache
+
+
+def _save_cache(profile):
+    path = _cache_path(profile)
+    cache = _CACHES.get(path)
+    if cache is None:
+        return
+    raw = json.dumps(cache).encode()
+    if profile.get("cache_encryption_key"):
+        raw = _fernet(profile["cache_encryption_key"]).encrypt(raw)
+    folder = os.path.dirname(path) or "."
+    try:
+        os.makedirs(folder, exist_ok=True)
+        fd, tmp = tempfile.mkstemp(dir=folder, prefix=".vault_salt_sdb_", suffix=".tmp")
+        try:
+            with os.fdopen(fd, "wb") as fh:
+                fh.write(raw)
+            os.chmod(tmp, 0o644)  # readable; pair with cache_encryption_key to keep contents safe
+            os.replace(tmp, path)          # atomic
+            tmp = None
+        finally:
+            if tmp and os.path.exists(tmp):
+                try:
+                    os.remove(tmp)
+                except OSError:
+                    pass
+    except salt.exceptions.CommandExecutionError:
+        raise
+    except Exception as exc:
+        log.warning("vault_salt_sdb: failed to persist cache %s: %s", path, exc)
+
+
+# --------------------------------------------------------------------------- #
+# auth
+# --------------------------------------------------------------------------- #
+def _auth(profile):
+    """Resolve the auth mapping. Inline `auth:` is the base; an external
+    `auth_file` (default DEFAULT_AUTH_FILE) is overlaid on top (file wins), so
+    credentials can live outside the Salt config. The file holds the same keys
+    as the inline block, optionally wrapped in a top-level `auth:`."""
+    inline = dict(profile.get("auth") or {})
+    explicit = "auth_file" in profile
+    path = os.path.expanduser(profile.get("auth_file", DEFAULT_AUTH_FILE))
+
+    if path in _AUTH_FILES:
+        file_auth = _AUTH_FILES[path]
+    elif os.path.exists(path):
+        try:
+            with open(path) as fh:
+                loaded = yaml.safe_load(fh) or {}
+        except Exception as exc:
+            raise salt.exceptions.CommandExecutionError(
+                "vault_salt_sdb: cannot read auth_file {}: {}".format(path, exc)
+            )
+        if not isinstance(loaded, dict):
+            raise salt.exceptions.CommandExecutionError(
+                "vault_salt_sdb: auth_file {} must be a mapping "
+                "(method/role_id/secret_id/token)".format(path)
+            )
+        file_auth = loaded.get("auth", loaded)       # bare mapping or `auth:` wrapper
+        if not isinstance(file_auth, dict):
+            raise salt.exceptions.CommandExecutionError(
+                "vault_salt_sdb: 'auth' in {} must be a mapping".format(path)
+            )
+        _AUTH_FILES[path] = file_auth
+    elif explicit:
+        raise salt.exceptions.CommandExecutionError(
+            "vault_salt_sdb: auth_file not found: {}".format(path)
+        )
+    else:
+        file_auth = None
+
+    return {**inline, **file_auth} if file_auth else inline
+
+
+def _token(profile, force=False):
+    auth = _auth(profile)
+    method = auth.get("method", "token")
+    url = profile["url"].rstrip("/")
+
+    if method == "token":
+        token = auth.get("token")
+        if not token:
+            raise salt.exceptions.CommandExecutionError(
+                "vault_salt_sdb: auth:method is 'token' but auth:token is not set"
+            )
+        return token
+
+    if method != "approle":
+        raise salt.exceptions.CommandExecutionError(
+            "vault_salt_sdb: unsupported auth:method {!r} (use 'token' or 'approle')".format(method)
+        )
+
+    role_id = auth.get("role_id")
+    secret_id = auth.get("secret_id")
+    if not role_id or not secret_id:
+        raise salt.exceptions.CommandExecutionError(
+            "vault_salt_sdb: approle requires auth:role_id and auth:secret_id"
+        )
+
+    cache = _load_cache(profile)
+    ckey = hashlib.sha256("{}|{}".format(url, role_id).encode()).hexdigest()
+    if not force:
+        ent = cache["tokens"].get(ckey)
+        if ent and ent.get("expires_at", 0) - 10 > time.time():
+            return ent["token"]
+
+    r = _request(
+        profile, "POST", "{}/v1/auth/approle/login".format(url),
+        json={"role_id": role_id, "secret_id": secret_id},
+    )
+    if r.status_code in (400, 403):
+        raise salt.exceptions.CommandExecutionError(
+            "vault_salt_sdb: AppRole login denied (check role_id/secret_id)"
+        )
+    if r.status_code == 503:
+        _down(profile, "Vault sealed during AppRole login (503)")
+    if r.status_code >= 500:
+        _down(profile, "Vault error {} during AppRole login".format(r.status_code))
+    if r.status_code != 200:
+        raise salt.exceptions.CommandExecutionError(
+            "vault_salt_sdb: unexpected AppRole login HTTP {}".format(r.status_code)
+        )
+    try:
+        body_auth = r.json()["auth"]
+        token = body_auth["client_token"]
+    except (ValueError, KeyError) as exc:
+        raise salt.exceptions.CommandExecutionError(
+            "vault_salt_sdb: unexpected AppRole login response: {}".format(exc)
+        )
+
+    ttl = body_auth.get("lease_duration", 0) or 60
+    cache["tokens"][ckey] = {"token": token, "expires_at": time.time() + ttl}
+    _save_cache(profile)
+    return token
+
+
+# --------------------------------------------------------------------------- #
+# KV version
+# --------------------------------------------------------------------------- #
+def _detect_kv_version(profile, url, mount):
+    """Return (version, confirmed)."""
+    try:
+        token = _token(profile)
+        r = _request(
+            profile, "GET", "{}/v1/sys/internal/ui/mounts/{}".format(url, mount),
+            headers={"X-Vault-Token": token},
+        )
+    except _VaultUnreachable:
+        log.warning("vault_salt_sdb: Vault unreachable while detecting KV version of %r; assuming v2", mount)
+        return 2, False
+
+    if r.status_code == 200:
+        try:
+            opts = (r.json().get("data") or {}).get("options") or {}
+            return int(opts.get("version", 2)), True
+        except (ValueError, TypeError):
+            pass
+    log.warning(
+        "vault_salt_sdb: KV version detect for %r returned HTTP %s; assuming v2 "
+        "(grant read on sys/internal/ui/mounts/%s, or set kv_version explicitly)",
+        mount, r.status_code, mount,
+    )
+    return 2, False
+
+
+def _kv_version(profile, url, mount):
+    if profile.get("kv_version"):
+        return int(profile["kv_version"])
+    cache = _load_cache(profile)
+    ckey = "{}|{}".format(url, mount)
+    if ckey in cache["kv"]:
+        return cache["kv"][ckey]
+    version, confirmed = _detect_kv_version(profile, url, mount)
+    if confirmed:
+        cache["kv"][ckey] = version
+        _save_cache(profile)
+    return version
+
+
+# --------------------------------------------------------------------------- #
+# read
+# --------------------------------------------------------------------------- #
+def _read_secret(profile, url, mount, path):
+    version = _kv_version(profile, url, mount)
+    if version == 2:
+        api = "{}/v1/{}/data/{}".format(url, mount, path)
+    else:
+        api = "{}/v1/{}/{}".format(url, mount, path)
+
+    r = _request(profile, "GET", api, headers={"X-Vault-Token": _token(profile)})
+    if r.status_code == 403:               # cached token may be stale -> refresh once
+        r = _request(profile, "GET", api, headers={"X-Vault-Token": _token(profile, force=True)})
+
+    if r.status_code == 403:
+        raise salt.exceptions.CommandExecutionError(
+            "vault_salt_sdb: Vault denied access to {}/{} (403)".format(mount, path)
+        )
+    if r.status_code == 404:
+        raise salt.exceptions.CommandExecutionError(
+            "vault_salt_sdb: secret not found: {}/{} (404)".format(mount, path)
+        )
+    if r.status_code == 503:
+        _down(profile, "Vault sealed/unavailable (503)")
+    if r.status_code >= 500:
+        _down(profile, "Vault server error {}".format(r.status_code))
+    if r.status_code != 200:
+        raise salt.exceptions.CommandExecutionError(
+            "vault_salt_sdb: unexpected HTTP {} for {}/{}".format(r.status_code, mount, path)
+        )
+
+    try:
+        body = r.json()
+    except ValueError as exc:
+        raise salt.exceptions.CommandExecutionError(
+            "vault_salt_sdb: invalid JSON from Vault for {}/{}: {}".format(mount, path, exc)
+        )
+    data = (body.get("data") or {}).get("data") if version == 2 else body.get("data")
+    if not isinstance(data, dict):
+        raise salt.exceptions.CommandExecutionError(
+            "vault_salt_sdb: no data at {}/{} (deleted version or empty secret?)".format(mount, path)
+        )
+    return data
+
+
+def _extract(data, field, path, cached=False):
+    if field in data:
+        return data[field]
+    available = ", ".join(sorted(data.keys())) or "(none)"
+    raise salt.exceptions.CommandExecutionError(
+        "vault_salt_sdb: key '{}' not found in secret '{}'. Available keys: {}".format(
+            field, path, available
+        )
+    )
+
+
+# --------------------------------------------------------------------------- #
+# sdb entrypoint
+# --------------------------------------------------------------------------- #
+def get(key, profile=None, **kwargs):
+    profile = profile or {}
+    if "url" not in profile:
+        raise salt.exceptions.CommandExecutionError("vault_salt_sdb: profile is missing 'url'")
+    url = profile["url"].rstrip("/")
+
+    parts = [p for p in str(key).split("/") if p]
+    if len(parts) < 3:
+        raise salt.exceptions.CommandExecutionError(
+            "vault_salt_sdb: URI must be <mount>/<path>/<key>, got {!r}".format(key)
+        )
+    mount, field, path = parts[0], parts[-1], "/".join(parts[1:-1])
+    skey = "{}|{}|{}".format(url, mount, path)
+    now = time.time()
+
+    # 0) in-memory per-render dedup: this path already resolved this process
+    if skey in _RENDER_SECRETS:
+        return _extract(_RENDER_SECRETS[skey], field, path, cached=True)
+
+    cache_on = bool(profile.get("cache_secrets"))
+    cache_fresh_for = int(profile.get("cache_fresh_for", 60))
+    cache_offline_max_age = int(profile.get("cache_offline_max_age", 3600))
+
+    # 1) persistent freshness window -> serve from cache, no Vault call
+    if cache_on and cache_fresh_for > 0:
+        ent = _load_cache(profile)["secrets"].get(skey)
+        if ent and (now - ent.get("cached_at", 0)) < cache_fresh_for:
+            log.debug(
+                "vault_salt_sdb: freshness cache hit for %s/%s (%ds old); Vault not contacted",
+                mount, path, int(now - ent.get("cached_at", 0)),
+            )
+            _RENDER_SECRETS[skey] = ent["data"]
+            return _extract(ent["data"], field, path, cached=True)
+
+    # 2) read from Vault
+    try:
+        data = _read_secret(profile, url, mount, path)
+    except _VaultUnreachable as exc:
+        # 3) outage fallback (Vault unreachable only; never on 403/404)
+        if cache_on and cache_offline_max_age > 0:
+            ent = _load_cache(profile)["secrets"].get(skey)
+            if ent and (now - ent.get("cached_at", 0)) < cache_offline_max_age:
+                log.warning(
+                    "vault_salt_sdb: Vault unreachable (%s); serving CACHED secret for "
+                    "%s/%s cached %ds ago",
+                    exc, mount, path, int(now - ent.get("cached_at", 0)),
+                )
+                _RENDER_SECRETS[skey] = ent["data"]
+                return _extract(ent["data"], field, path, cached=True)
+        raise salt.exceptions.CommandExecutionError(
+            "vault_salt_sdb: Vault unreachable and no usable cache for {}/{}: {}".format(mount, path, exc)
+        )
+
+    # success
+    _RENDER_SECRETS[skey] = data
+    if cache_on:
+        global _WARNED_PLAINTEXT
+        if (profile.get("warn_plaintext_cache", True)
+                and not profile.get("cache_encryption_key")
+                and not _WARNED_PLAINTEXT):
+            log.warning(
+                "vault_salt_sdb: cache_secrets is enabled without cache_encryption_key - the "
+                "value cache is stored UNENCRYPTED on disk. Set cache_encryption_key to encrypt it."
+            )
+            _WARNED_PLAINTEXT = True
+        cache = _load_cache(profile)
+        cache["secrets"][skey] = {"data": data, "cached_at": now}
+        _save_cache(profile)
+
+    return _extract(data, field, path, cached=False)

--- a/template_install.sh.example
+++ b/template_install.sh.example
@@ -36,4 +36,7 @@ TELEGRAM_TOKEN=xxx \
 	SALTSSH_RUNNER_SOURCE_IP_1=xxx \
 	SALTSSH_RUNNER_SOURCE_IP_2=xxx \
 	SALT_VERSION=xxx \
+	# optional - vault_salt_sdb secrets backend, uncomment both to enable (see README):
+	# VAULT_SDB_URL=https://vault.example.com \
+	# VAULT_SDB_PREFIX=iac/example \
 	./install.sh .. salt|salt-ssh

--- a/template_install.sh.example
+++ b/template_install.sh.example
@@ -37,6 +37,6 @@ TELEGRAM_TOKEN=xxx \
 	SALTSSH_RUNNER_SOURCE_IP_2=xxx \
 	SALT_VERSION=xxx \
 	# optional - vault_salt_sdb secrets backend, uncomment both to enable (see README):
-	# VAULT_SDB_URL=https://vault.example.com \
-	# VAULT_SDB_PREFIX=iac/example \
+	# VAULT_SALT_SDB_URL=https://vault.example.com \
+	# VAULT_SALT_SDB_PREFIX=iac/example \
 	./install.sh .. salt|salt-ssh


### PR DESCRIPTION
This pull request adds support for managing Salt secrets using HashiCorp Vault via a custom SDB driver (`vault_salt_sdb`). The integration is designed to be opt-in: all necessary components are installed by default but remain inactive unless Vault configuration variables are provided. The changes include new configuration files, installation logic, documentation, and Docker support to enable seamless use of Vault-stored secrets in Salt pillars.

**Vault SDB integration for Salt:**

* Added a custom SDB driver (`vault_salt_sdb`) for fetching secrets from HashiCorp Vault (KV v2), including the driver, configuration files, and pillar macro for referencing secrets in Salt pillar data. [[1]](diffhunk://#diff-a1f72687a60f4ba6a0df1c4c2f30b7ed986c02c9186af66a86100c98ff97f31bR1-R3) [[2]](diffhunk://#diff-4e55b0a5a48dcece1524ed9acc3d3038a8631fd61a5e9d1607c669cb79862a93R1-R16) [[3]](diffhunk://#diff-ebaec7cbbb132e6941e527a60c26609ccfcbbe36fcd167a42a87f36f6446d888R1) [[4]](diffhunk://#diff-39f47f4e6bdcd86d4247b62d317c1707b37571e447e4b94a9df34372fd256f0fR1) [[5]](diffhunk://#diff-719f92c31023d75fc522f09e217135d55f95e89c584ce3610c2f35dbe88410c4R1)

* Updated the installation logic in `install.sh` to conditionally configure Vault integration based on the presence of `VAULT_SALT_SDB_URL` and `VAULT_SALT_SDB_PREFIX` variables, ensuring the feature is only enabled when desired. [[1]](diffhunk://#diff-043df5bdbf6639d7a77e1d44c5226fd7371e5259a1e4df3a0dd5d64c30dca44fR94-R103) [[2]](diffhunk://#diff-043df5bdbf6639d7a77e1d44c5226fd7371e5259a1e4df3a0dd5d64c30dca44fR114-R115) [[3]](diffhunk://#diff-043df5bdbf6639d7a77e1d44c5226fd7371e5259a1e4df3a0dd5d64c30dca44fR345-R361)

**Documentation and usage:**

* Expanded `README.md` with detailed instructions for enabling, configuring, and using Vault secrets in Salt, including setup of credentials and pillar usage examples.

* Updated `template_install.sh.example` to document the new Vault-related environment variables.

**Docker and configuration wiring:**

* Modified `.docker-misc.bash` to automatically bind-mount the operator's Vault credentials file into the container if present, supporting local development and testing.

* Ensured all relevant configuration directories and files are copied into the Docker image and installed in the correct locations, including new `minion.d` wiring.

These changes make it easy to securely manage secrets in Salt using Vault, with minimal impact on repositories that do not require this feature.