### PR TITLE
feat(vault): oidc jwt support for gitlab pipelines requests to vault

### DIFF
--- a/.gitlab-ci.yml.salt
+++ b/.gitlab-ci.yml.salt
@@ -14,7 +14,17 @@ variables:
   GIT_STRATEGY: none
   GIT_SUBMODULE_STRATEGY: none
 
+#vault## GitLab OIDC: mint a short-lived JWT that the salt vault_salt_sdb driver exchanges for
+#vault## a Vault token (jwt auth). Only jobs that render vault pillar in the CI container extend
+#vault## this; the salt-master (_1/_2) jobs render on the master and use its AppRole auth.conf.
+#vault## aud must match the Vault jwt role's bound_audiences.
+#vault#.vault_oidc:
+#vault#  id_tokens:
+#vault#    VAULT_ID_TOKEN:
+#vault#      aud: __VAULT_SALT_SDB_URL__
+
 build:
+#vault#  extends: .vault_oidc
   tags:
     - __DEV_RUNNER__
   stage: build
@@ -30,7 +40,9 @@ build:
   script:
     - echo IMAGE $CI_PROJECT_PATH:$CI_PIPELINE_ID
     - docker build --pull --tag $CI_PROJECT_PATH:$CI_PIPELINE_ID --build-arg SALT_VERSION=__SALT_VERSION__ .
-    - docker run --rm $CI_PROJECT_PATH:$CI_PIPELINE_ID -- /.check_pillar_for_roster.sh
+    # -e VAULT_ID_TOKEN forwards the OIDC JWT into the check container without exposing it in
+    # docker's argv. Inert when vault is disabled (the var is unset -> nothing forwarded).
+    - docker run --rm -e VAULT_ID_TOKEN $CI_PROJECT_PATH:$CI_PIPELINE_ID -- /.check_pillar_for_roster.sh
 
 push:
   tags:
@@ -136,6 +148,7 @@ salt_cmd_2:
     - __SALT_MASTER_2_NAME__
 
 salt_cmd:
+#vault#  extends: .vault_oidc
   tags:
     - salt-ssh
   stage: run_1
@@ -171,6 +184,7 @@ rsnapshot_backup_update_config_2:
     - __SALT_MASTER_2_NAME__
 
 rsnapshot_backup_update_config:
+#vault#  extends: .vault_oidc
   tags:
     - salt-ssh
   stage: run_1
@@ -211,6 +225,7 @@ rsnapshot_backup_sync_2:
     - __SALT_MASTER_2_NAME__
 
 rsnapshot_backup_sync:
+#vault#  extends: .vault_oidc
   tags:
     - salt-ssh
   stage: run_2
@@ -259,6 +274,7 @@ rsnapshot_backup_rotate_2:
     - __SALT_MASTER_2_NAME__
 
 rsnapshot_backup_rotate:
+#vault#  extends: .vault_oidc
   tags:
     - salt-ssh
   stage: run_3
@@ -298,6 +314,7 @@ rsnapshot_backup_check_backup_2:
     - __SALT_MASTER_2_NAME__
 
 rsnapshot_backup_check_backup:
+#vault#  extends: .vault_oidc
   tags:
     - salt-ssh
   stage: run_4
@@ -337,6 +354,7 @@ rsnapshot_backup_check_coverage_2:
     - __SALT_MASTER_2_NAME__
 
 rsnapshot_backup_check_coverage:
+#vault#  extends: .vault_oidc
   tags:
     - salt-ssh
   stage: run_5

--- a/.gitlab-ci.yml.salt-ssh
+++ b/.gitlab-ci.yml.salt-ssh
@@ -11,7 +11,16 @@ variables:
   GIT_STRATEGY: none
   GIT_SUBMODULE_STRATEGY: none
 
+#vault## GitLab OIDC: mint a short-lived JWT that the salt vault_salt_sdb driver exchanges for
+#vault## a Vault token (jwt auth). Every job that renders vault-backed pillar must extend this.
+#vault## aud must match the Vault jwt role's bound_audiences.
+#vault#.vault_oidc:
+#vault#  id_tokens:
+#vault#    VAULT_ID_TOKEN:
+#vault#      aud: __VAULT_SALT_SDB_URL__
+
 build:
+#vault#  extends: .vault_oidc
   tags:
     - __DEV_RUNNER__
   stage: build
@@ -27,7 +36,9 @@ build:
   script:
     - echo IMAGE $CI_PROJECT_PATH:$CI_PIPELINE_ID
     - docker build --pull --tag $CI_PROJECT_PATH:$CI_PIPELINE_ID --build-arg SALT_VERSION=__SALT_VERSION__ .
-    - docker run --rm $CI_PROJECT_PATH:$CI_PIPELINE_ID -- /.check_pillar_for_roster.sh
+    # -e VAULT_ID_TOKEN forwards the OIDC JWT into the check container without exposing it in
+    # docker's argv. Inert when vault is disabled (the var is unset -> nothing forwarded).
+    - docker run --rm -e VAULT_ID_TOKEN $CI_PROJECT_PATH:$CI_PIPELINE_ID -- /.check_pillar_for_roster.sh
 
 push:
   tags:
@@ -44,6 +55,7 @@ push:
     - docker push $CI_REGISTRY/$CI_PROJECT_PATH:$CI_COMMIT_REF_SLUG
 
 salt_cmd:
+#vault#  extends: .vault_oidc
   tags:
     - __PROD_RUNNER__
   stage: run_1
@@ -56,6 +68,7 @@ salt_cmd:
     - /srv/scripts/salt-ssh/send_notify_devilry.sh
 
 rsnapshot_backup_update_config:
+#vault#  extends: .vault_oidc
   tags:
     - __PROD_RUNNER__
   stage: run_1
@@ -68,6 +81,7 @@ rsnapshot_backup_update_config:
     - /srv/scripts/salt-ssh/send_notify_devilry.sh
 
 rsnapshot_backup_sync:
+#vault#  extends: .vault_oidc
   tags:
     - __PROD_RUNNER__
   stage: run_2
@@ -91,6 +105,7 @@ rsnapshot_backup_sync:
     - /srv/scripts/salt-ssh/send_notify_devilry.sh
 
 rsnapshot_backup_rotate:
+#vault#  extends: .vault_oidc
   tags:
     - __PROD_RUNNER__
   stage: run_3
@@ -105,6 +120,7 @@ rsnapshot_backup_rotate:
     - rm -f rsnapshot_backup_sync_status
 
 rsnapshot_backup_check_backup:
+#vault#  extends: .vault_oidc
   tags:
     - __PROD_RUNNER__
   stage: run_4
@@ -119,6 +135,7 @@ rsnapshot_backup_check_backup:
     - rm -f rsnapshot_backup_sync_status
 
 rsnapshot_backup_check_coverage:
+#vault#  extends: .vault_oidc
   tags:
     - __PROD_RUNNER__
   stage: run_5

--- a/README.md
+++ b/README.md
@@ -45,21 +45,50 @@ its `extmods.conf` and the `minion.d` wiring are always installed but stay dorma
 profile is configured, so repos that do not use Vault are unaffected.
 
 ## Enable at install time
-Set both vars in `template_install.sh` (presence of `VAULT_SALT_SDB_URL` turns the feature on):
+Set the three vars in `template_install.sh` (presence of `VAULT_SALT_SDB_URL` turns the feature on):
 ```
 VAULT_SALT_SDB_URL=https://vault.example.com \
 VAULT_SALT_SDB_PREFIX=iac/example \
+VAULT_SALT_SDB_JWT_ROLE=salt-ci-example \
 ```
-- `VAULT_SALT_SDB_URL` - Vault address. If unset, `install.sh` strips out the profile and the macro
-  (the driver itself stays installed, dormant).
+- `VAULT_SALT_SDB_URL` - Vault address. If unset, `install.sh` strips out the profile, the macro
+  and the CI OIDC lines (the driver itself stays installed, dormant).
 - `VAULT_SALT_SDB_PREFIX` - per-repo KV path prefix, e.g. `iac/<project>`. Required when the URL is set.
+- `VAULT_SALT_SDB_JWT_ROLE` - Vault jwt auth role name for CI (see *CI auth* below). Required when
+  the URL is set. Baked into the profile's inline `auth:` block.
 
-This generates `etc/salt/master.d/vault_salt_sdb.conf` (mirrored into `minion.d` via symlink).
+This generates `etc/salt/master.d/vault_salt_sdb.conf` (mirrored into `minion.d` via symlink) and
+un-comments the `#vault#` OIDC lines in `.gitlab-ci.yml`.
 
 ## Runtime auth
-The profile loads credentials from `/root/.config/vault_salt_sdb/auth.conf`, kept OUT of the
-repo. Provide it on each Salt Master and on the salt-ssh runner (for local docker runs it is
-bind-mounted automatically, see `.docker-misc.bash`):
+The driver authenticates two ways from one profile, chosen by whether an `auth_file` is present:
+
+**CI (keyless, GitLab OIDC).** The generated `.gitlab-ci.yml` gives every pillar-rendering job an
+`id_tokens:` block that mints a short-lived JWT as `$VAULT_ID_TOKEN`; the profile's inline
+`auth: {method: jwt, role: <VAULT_SALT_SDB_JWT_ROLE>}` exchanges it for a short-lived Vault token.
+No long-lived secret is stored on the runner. Configure Vault once:
+```
+vault auth enable jwt
+vault write auth/jwt/config oidc_discovery_url="https://gitlab.example.com" \
+                            bound_issuer="https://gitlab.example.com"
+vault policy write salt-ci-example - <<'EOF'
+path "iac/data/example/*" { capabilities = ["read"] }
+EOF
+vault write auth/jwt/role/salt-ci-example - <<'EOF'
+{ "role_type": "jwt", "user_claim": "project_path",
+  "bound_audiences": ["https://vault.example.com"],
+  "bound_claims": {"project_path": "group/subgroup/example"},
+  "token_policies": ["salt-ci-example"], "token_ttl": "5m", "token_max_ttl": "10m",
+  "token_no_default_policy": true }
+EOF
+```
+The role name must match `VAULT_SALT_SDB_JWT_ROLE`; the KV read path is `<mount>/data/<project>/*`;
+`bound_audiences` must equal the `aud` in `.gitlab-ci.yml` (the Vault URL). Vault must be able to
+reach the GitLab OIDC discovery URL. Missing/mis-set Vault config fails the pillar check closed.
+
+**Salt Masters & local dev (AppRole).** Drop an `auth.conf` at `/root/.config/vault_salt_sdb/auth.conf`
+(kept OUT of the repo); when present it OVERRIDES the inline JWT auth, so persistent masters and
+local `drun` (which bind-mounts it automatically, see `.docker-misc.bash`) use AppRole instead:
 ```
 mkdir -p ~/.config/vault_salt_sdb
 cat > ~/.config/vault_salt_sdb/auth.conf <<'EOF'

--- a/etc/salt/master.d/vault_salt_sdb.conf
+++ b/etc/salt/master.d/vault_salt_sdb.conf
@@ -9,6 +9,14 @@ vault_salt_sdb:
   cache_fresh_for: 60
   cache_offline_max_age: 3600
   cache_path: /root/.cache/vault_salt_sdb/cache.json
+  # CI authenticates to Vault via GitLab OIDC: the build/run jobs' id_tokens: block injects
+  # a short-lived JWT as $VAULT_ID_TOKEN, which the driver exchanges for a Vault token. No
+  # long-lived secret on the runner. On persistent salt-masters and local dev, auth_file
+  # below (AppRole) exists and OVERRIDES this inline block per-key (file wins), so the one
+  # config does keyless JWT in CI and AppRole everywhere else.
+  auth:
+    method: jwt
+    role: __VAULT_SALT_SDB_JWT_ROLE__     # Vault jwt role bound to this project's project_path
   auth_file: /root/.config/vault_salt_sdb/auth.conf
   # Cache is plaintext at 0600 on a dedicated, root-only host — same posture as
   # auth.conf next to it — so silence the unencrypted-cache warning (it would

--- a/install.sh
+++ b/install.sh
@@ -101,6 +101,11 @@ function sed_inplace_common () {
 	else
 		local LOCAL_VAULT_SALT_SDB_PREFIX=${VAULT_SALT_SDB_PREFIX}
 	fi
+	if [[ -z ${VAULT_SALT_SDB_JWT_ROLE} ]]; then
+		local LOCAL_VAULT_SALT_SDB_JWT_ROLE=__not_set_in_template_install__
+	else
+		local LOCAL_VAULT_SALT_SDB_JWT_ROLE=${VAULT_SALT_SDB_JWT_ROLE}
+	fi
 	sed -i \
 		-e "s/__CLIENT__/${CLIENT}/g" \
 		-e "s/__CLIENT_FULL__/${CLIENT_FULL}/g" \
@@ -113,6 +118,7 @@ function sed_inplace_common () {
 		-e "s/__ALERTA_API_KEY__/${LOCAL_ALERTA_API_KEY}/g" \
 		-e "s#__VAULT_SALT_SDB_URL__#${LOCAL_VAULT_SALT_SDB_URL}#g" \
 		-e "s#__VAULT_SALT_SDB_PREFIX__#${LOCAL_VAULT_SALT_SDB_PREFIX}#g" \
+		-e "s#__VAULT_SALT_SDB_JWT_ROLE__#${LOCAL_VAULT_SALT_SDB_JWT_ROLE}#g" \
 		-e "s/__HB_RECEIVER_HN__/${HB_RECEIVER_HN}/g" \
 		-e "s/__HB_TOKEN__/${HB_TOKEN}/g" \
 		-e "s/__SENTRY_DOMAIN__/${SENTRY_DOMAIN}/g" \
@@ -348,15 +354,19 @@ rsync_without_delete include $1/include
 # vault_salt_sdb - the driver (salt/extmods/sdb), extmods.conf and the minion.d wiring
 # stay installed unconditionally (harmless when idle, ready for a manual setup later;
 # minion.d/extmods.conf is also what lets salt-call --local find the driver). The toggle
-# only governs the operator-facing profile that bakes in URL/prefix and the macro using it.
+# only governs the operator-facing profile that bakes in URL/prefix/jwt-role, the macro
+# using it, and the CI OIDC (#vault#) lines that mint the JWT for the pillar check.
 if [[ -n ${VAULT_SALT_SDB_URL} ]]; then
 	if [[ -z ${VAULT_SALT_SDB_PREFIX} ]]; then echo Var VAULT_SALT_SDB_PREFIX required when VAULT_SALT_SDB_URL is set; exit 1; fi
+	if [[ -z ${VAULT_SALT_SDB_JWT_ROLE} ]]; then echo Var VAULT_SALT_SDB_JWT_ROLE required when VAULT_SALT_SDB_URL is set; exit 1; fi
 	sed_inplace_common $1/etc/salt/master.d/vault_salt_sdb.conf
 	sed_inplace_common $1/pillar/vault_salt_sdb.jinja
+	sed -i -e "s/#vault#//" $1/.gitlab-ci.yml          # enable the CI OIDC (id_tokens) lines
 else
 	rm -f $1/etc/salt/master.d/vault_salt_sdb.conf
 	rm -f $1/etc/salt/minion.d/vault_salt_sdb.conf
 	rm -f $1/pillar/vault_salt_sdb.jinja
+	sed -i -e "/#vault#/d" $1/.gitlab-ci.yml           # strip the CI OIDC lines entirely
 fi
 
 # Get inside templated repo

--- a/salt/extmods/sdb/vault_salt_sdb.py
+++ b/salt/extmods/sdb/vault_salt_sdb.py
@@ -1,5 +1,5 @@
 """
-SDB module: read HashiCorp Vault KV secrets directly (token / AppRole),
+SDB module: read HashiCorp Vault KV secrets directly (token / AppRole / JWT-OIDC),
 with stock-sdb-compatible URI syntax, a file-based token cache, an optional
 two-tier value cache (freshness + outage fallback), optional cache encryption,
 fail-closed errors, an in-process circuit breaker, and per-render path dedup.
@@ -9,17 +9,24 @@ Version history:
 * 2026-06-16: initial version
 * 2026-06-21: cache file written 0600 (was 0644); dropped dead `cached` arg from
   _extract; documented lease_duration-0 fallback and cache_fresh_for staleness window.
+* 2026-06-29: added `jwt` auth method (GitLab CI OIDC: exchange id_tokens JWT for a
+  short-lived Vault token); refactored AppRole/JWT onto a shared `_login`; an explicit
+  but absent auth_file is no longer fatal when inline auth is present (CI uses inline
+  JWT, persistent masters / local dev override with an AppRole auth_file).
 
 Profile (e.g. /etc/salt/master.d/vault.conf):
 
     custom_vault_driver:
       driver: vault_salt_sdb
-      url: https://vault.dev.opscore.org
+      url: https://vault.dev.example.org
       auth:                         # inline auth (optional when auth_file is used)
-        method: approle          # or: token
+        method: approle          # or: token, jwt
         role_id: <role-id>
         secret_id: <secret-id>
         # method: token -> token: <token>
+        # method: jwt (GitLab CI OIDC) -> role: <vault-jwt-role>
+        #   JWT source: $VAULT_ID_TOKEN (default) | jwt_env: <ENV> | jwt_file: <path> | jwt: <inline>
+        #   mount: jwt (optional, the Vault jwt auth mount path; default 'jwt')
       auth_file: ~/.config/vault_salt_sdb/auth.conf   # optional; load auth from a separate
                                     # file so credentials stay OUT of this config. Keys there
                                     # OVERRIDE the inline auth above. Used automatically if it exists.
@@ -38,8 +45,8 @@ Profile (e.g. /etc/salt/master.d/vault.conf):
                                     # set false to silence it, e.g. in the minion.d/check config)
 
 URI:  sdb://<profile>/<mount>/<path>/<key>          (key = last segment)
-      sdb://custom_vault_driver/salt/opscore/tst/nextcloud/admin_pass
-      -> GET <url>/v1/salt/data/opscore/tst/nextcloud ; return key 'admin_pass'
+      sdb://custom_vault_driver/salt/example/tst/nextcloud/admin_pass
+      -> GET <url>/v1/salt/data/example/tst/nextcloud ; return key 'admin_pass'
 
 Performance during an outage:
   * Circuit breaker: the first connection failure is recorded in the cache file
@@ -287,13 +294,85 @@ def _auth(profile):
             )
         _AUTH_FILES[path] = file_auth
     elif explicit:
-        raise salt.exceptions.CommandExecutionError(
-            "vault_salt_sdb: auth_file not found: {}".format(path)
-        )
+        # An explicitly configured auth_file that is absent is only fatal when there is
+        # no usable inline auth to fall back to. This lets one shared profile carry inline
+        # JWT auth (used in CI, where no auth_file exists) while persistent masters / local
+        # dev drop an AppRole auth_file alongside it that takes over when present.
+        if inline:
+            log.debug("vault_salt_sdb: auth_file %s absent; using inline auth", path)
+            file_auth = None
+        else:
+            raise salt.exceptions.CommandExecutionError(
+                "vault_salt_sdb: auth_file not found: {}".format(path)
+            )
     else:
         file_auth = None
 
     return {**inline, **file_auth} if file_auth else inline
+
+
+def _jwt_token(auth):
+    """Resolve the OIDC JWT for jwt auth: inline auth:jwt, else the env var named by
+    auth:jwt_env (default VAULT_ID_TOKEN, injected by GitLab CI id_tokens), else
+    auth:jwt_file."""
+    jwt = auth.get("jwt")
+    if jwt:
+        return jwt
+    env = auth.get("jwt_env", "VAULT_ID_TOKEN")
+    jwt = os.environ.get(env)
+    if jwt:
+        return jwt
+    jwt_file = auth.get("jwt_file")
+    if jwt_file:
+        path = os.path.expanduser(jwt_file)
+        try:
+            with open(path) as fh:
+                return fh.read().strip()
+        except Exception as exc:
+            raise salt.exceptions.CommandExecutionError(
+                "vault_salt_sdb: cannot read jwt_file {}: {}".format(path, exc)
+            )
+    raise salt.exceptions.CommandExecutionError(
+        "vault_salt_sdb: jwt auth has no token (set ${} or auth:jwt_file)".format(env)
+    )
+
+
+def _login(profile, url, login_path, payload, ckey, force, what):
+    """Shared token-issuing login (AppRole / JWT): return a still-valid cached token,
+    else POST to login_path, cache the issued client_token under ckey, and return it."""
+    cache = _load_cache(profile)
+    if not force:
+        ent = cache["tokens"].get(ckey)
+        if ent and ent.get("expires_at", 0) - 10 > time.time():
+            return ent["token"]
+
+    r = _request(profile, "POST", "{}/v1/{}".format(url, login_path), json=payload)
+    if r.status_code in (400, 403):
+        raise salt.exceptions.CommandExecutionError(
+            "vault_salt_sdb: {} login denied (HTTP {})".format(what, r.status_code)
+        )
+    if r.status_code == 503:
+        _down(profile, "Vault sealed during {} login (503)".format(what))
+    if r.status_code >= 500:
+        _down(profile, "Vault error {} during {} login".format(r.status_code, what))
+    if r.status_code != 200:
+        raise salt.exceptions.CommandExecutionError(
+            "vault_salt_sdb: unexpected {} login HTTP {}".format(what, r.status_code)
+        )
+    try:
+        body_auth = r.json()["auth"]
+        token = body_auth["client_token"]
+    except (ValueError, KeyError) as exc:
+        raise salt.exceptions.CommandExecutionError(
+            "vault_salt_sdb: unexpected {} login response: {}".format(what, exc)
+        )
+
+    # lease_duration 0 (e.g. root/non-expiring tokens) -> fall back to a short 60s
+    # cache rather than treating the token as valid forever.
+    ttl = body_auth.get("lease_duration", 0) or 60
+    cache["tokens"][ckey] = {"token": token, "expires_at": time.time() + ttl}
+    _save_cache(profile)
+    return token
 
 
 def _token(profile, force=False):
@@ -309,55 +388,39 @@ def _token(profile, force=False):
             )
         return token
 
-    if method != "approle":
-        raise salt.exceptions.CommandExecutionError(
-            "vault_salt_sdb: unsupported auth:method {!r} (use 'token' or 'approle')".format(method)
+    if method == "approle":
+        role_id = auth.get("role_id")
+        secret_id = auth.get("secret_id")
+        if not role_id or not secret_id:
+            raise salt.exceptions.CommandExecutionError(
+                "vault_salt_sdb: approle requires auth:role_id and auth:secret_id"
+            )
+        ckey = hashlib.sha256("{}|approle|{}".format(url, role_id).encode()).hexdigest()
+        return _login(
+            profile, url, "auth/approle/login",
+            {"role_id": role_id, "secret_id": secret_id},
+            ckey, force, "AppRole",
         )
 
-    role_id = auth.get("role_id")
-    secret_id = auth.get("secret_id")
-    if not role_id or not secret_id:
-        raise salt.exceptions.CommandExecutionError(
-            "vault_salt_sdb: approle requires auth:role_id and auth:secret_id"
+    if method == "jwt":
+        # GitLab CI OIDC: exchange the job's id_tokens JWT for a short-lived Vault token.
+        role = auth.get("role")
+        if not role:
+            raise salt.exceptions.CommandExecutionError(
+                "vault_salt_sdb: jwt auth requires auth:role"
+            )
+        mount = auth.get("mount", "jwt")
+        jwt = _jwt_token(auth)
+        ckey = hashlib.sha256("{}|jwt|{}|{}".format(url, mount, role).encode()).hexdigest()
+        return _login(
+            profile, url, "auth/{}/login".format(mount),
+            {"role": role, "jwt": jwt},
+            ckey, force, "JWT",
         )
 
-    cache = _load_cache(profile)
-    ckey = hashlib.sha256("{}|{}".format(url, role_id).encode()).hexdigest()
-    if not force:
-        ent = cache["tokens"].get(ckey)
-        if ent and ent.get("expires_at", 0) - 10 > time.time():
-            return ent["token"]
-
-    r = _request(
-        profile, "POST", "{}/v1/auth/approle/login".format(url),
-        json={"role_id": role_id, "secret_id": secret_id},
+    raise salt.exceptions.CommandExecutionError(
+        "vault_salt_sdb: unsupported auth:method {!r} (use 'token', 'approle' or 'jwt')".format(method)
     )
-    if r.status_code in (400, 403):
-        raise salt.exceptions.CommandExecutionError(
-            "vault_salt_sdb: AppRole login denied (check role_id/secret_id)"
-        )
-    if r.status_code == 503:
-        _down(profile, "Vault sealed during AppRole login (503)")
-    if r.status_code >= 500:
-        _down(profile, "Vault error {} during AppRole login".format(r.status_code))
-    if r.status_code != 200:
-        raise salt.exceptions.CommandExecutionError(
-            "vault_salt_sdb: unexpected AppRole login HTTP {}".format(r.status_code)
-        )
-    try:
-        body_auth = r.json()["auth"]
-        token = body_auth["client_token"]
-    except (ValueError, KeyError) as exc:
-        raise salt.exceptions.CommandExecutionError(
-            "vault_salt_sdb: unexpected AppRole login response: {}".format(exc)
-        )
-
-    # lease_duration 0 (e.g. root/non-expiring tokens) -> fall back to a short 60s
-    # cache rather than treating the token as valid forever.
-    ttl = body_auth.get("lease_duration", 0) or 60
-    cache["tokens"][ckey] = {"token": token, "expires_at": time.time() + ttl}
-    _save_cache(profile)
-    return token
 
 
 # --------------------------------------------------------------------------- #

--- a/template_install.sh.example
+++ b/template_install.sh.example
@@ -36,7 +36,8 @@ TELEGRAM_TOKEN=xxx \
 	SALTSSH_RUNNER_SOURCE_IP_1=xxx \
 	SALTSSH_RUNNER_SOURCE_IP_2=xxx \
 	SALT_VERSION=xxx \
-	# optional - vault_salt_sdb secrets backend, uncomment both to enable (see README):
+	# optional - vault_salt_sdb secrets backend, uncomment all three to enable (see README):
 	# VAULT_SALT_SDB_URL=https://vault.example.com \
 	# VAULT_SALT_SDB_PREFIX=iac/example \
+	# VAULT_SALT_SDB_JWT_ROLE=salt-ci-example \
 	./install.sh .. salt|salt-ssh


### PR DESCRIPTION
This pull request introduces support for GitLab OIDC (OpenID Connect) JWT authentication in the Salt Vault SDB driver and its associated CI/CD pipeline templates. The main goal is to enable keyless, short-lived Vault access for CI jobs, while maintaining backward compatibility and secure fallback to AppRole authentication for persistent Salt masters and local development. The changes update documentation, configuration templates, and installation scripts to support this dual-authentication approach.

**Key changes include:**

**1. GitLab OIDC JWT Integration for CI Jobs**
- Added a `.vault_oidc` template block and corresponding `extends` lines to `.gitlab-ci.yml.salt` and `.gitlab-ci.yml.salt-ssh` to mint a short-lived JWT (`$VAULT_ID_TOKEN`) for CI jobs that render Vault-backed pillar data. This JWT is exchanged for a Vault token via the Salt Vault SDB driver. [[1]](diffhunk://#diff-ce57f944d2922ae33d99b9b4edafbe531081c8687300d16f88a072314a80efb6R17-R27) [[2]](diffhunk://#diff-ce57f944d2922ae33d99b9b4edafbe531081c8687300d16f88a072314a80efb6L33-R45) [[3]](diffhunk://#diff-ce57f944d2922ae33d99b9b4edafbe531081c8687300d16f88a072314a80efb6R151) [[4]](diffhunk://#diff-ce57f944d2922ae33d99b9b4edafbe531081c8687300d16f88a072314a80efb6R187) [[5]](diffhunk://#diff-ce57f944d2922ae33d99b9b4edafbe531081c8687300d16f88a072314a80efb6R228) [[6]](diffhunk://#diff-ce57f944d2922ae33d99b9b4edafbe531081c8687300d16f88a072314a80efb6R277) [[7]](diffhunk://#diff-ce57f944d2922ae33d99b9b4edafbe531081c8687300d16f88a072314a80efb6R317) [[8]](diffhunk://#diff-ce57f944d2922ae33d99b9b4edafbe531081c8687300d16f88a072314a80efb6R357) [[9]](diffhunk://#diff-81aeba17df8c92889969521acfa11165a400668b6a7634a219591bbed997d92eR14-R23) [[10]](diffhunk://#diff-81aeba17df8c92889969521acfa11165a400668b6a7634a219591bbed997d92eL30-R41) [[11]](diffhunk://#diff-81aeba17df8c92889969521acfa11165a400668b6a7634a219591bbed997d92eR58) [[12]](diffhunk://#diff-81aeba17df8c92889969521acfa11165a400668b6a7634a219591bbed997d92eR71) [[13]](diffhunk://#diff-81aeba17df8c92889969521acfa11165a400668b6a7634a219591bbed997d92eR84) [[14]](diffhunk://#diff-81aeba17df8c92889969521acfa11165a400668b6a7634a219591bbed997d92eR108) [[15]](diffhunk://#diff-81aeba17df8c92889969521acfa11165a400668b6a7634a219591bbed997d92eR123) [[16]](diffhunk://#diff-81aeba17df8c92889969521acfa11165a400668b6a7634a219591bbed997d92eR138)

**2. Vault SDB Driver Enhancements**
- Extended the Salt Vault SDB driver (`vault_salt_sdb.py`) to support the `jwt` authentication method, including logic to prefer an `auth_file` (AppRole) when present, but gracefully fall back to inline JWT auth in CI environments. Improved error handling and documentation for this dual-mode authentication. [[1]](diffhunk://#diff-fb67f6dbd937aa561e0db150ad4c68add72f2cce82d862679e56bd73ed9f0165L2-R2) [[2]](diffhunk://#diff-fb67f6dbd937aa561e0db150ad4c68add72f2cce82d862679e56bd73ed9f0165R12-R29) [[3]](diffhunk://#diff-fb67f6dbd937aa561e0db150ad4c68add72f2cce82d862679e56bd73ed9f0165L41-R49) [[4]](diffhunk://#diff-fb67f6dbd937aa561e0db150ad4c68add72f2cce82d862679e56bd73ed9f0165R297-R304)

**3. Installation and Configuration Updates**
- Updated `install.sh` to require and substitute the new `VAULT_SALT_SDB_JWT_ROLE` variable, ensure all three Vault-related variables are set for OIDC-enabled installs, and enable or remove the OIDC-related lines in `.gitlab-ci.yml` as appropriate. [[1]](diffhunk://#diff-043df5bdbf6639d7a77e1d44c5226fd7371e5259a1e4df3a0dd5d64c30dca44fR104-R108) [[2]](diffhunk://#diff-043df5bdbf6639d7a77e1d44c5226fd7371e5259a1e4df3a0dd5d64c30dca44fR121) [[3]](diffhunk://#diff-043df5bdbf6639d7a77e1d44c5226fd7371e5259a1e4df3a0dd5d64c30dca44fL351-R369)

**4. Configuration and Documentation Improvements**
- Updated `vault_salt_sdb.conf` to include an inline `auth` block for JWT, with explanatory comments about dual-mode authentication.
- Expanded the `README.md` with detailed instructions for enabling OIDC, configuring Vault roles, and the new dual-mode authentication behavior.

These changes together provide a more secure, flexible, and maintainable approach to Vault authentication in both CI and persistent environments.